### PR TITLE
miscellaneous fixes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,4 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+cran-comments\.md
+\.travis\.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
 .Rproj.user
-.Rproj
 .Rhistory
 .RData
-
 .httr-oauth
 .httr-oauth-SUSPENDED
-.Rbuildignore
 inst/doc
-
-*.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,9 @@ Authors@R: c(person("Mark", "Edmondson",email = "r@sunholo.com",
            person("Jennifer", "Bryan",email="jenny@stat.ubc.ca", role = "ctb"))
 Description: Provides an interface with the Google Search Console API v3, 
     formally called Google Webmaster Tools. 
-URL: http://www.google.com/webmasters/tools/, https://developers.google.com/webmaster-tools/
+URL: https://github.com/MarkEdmondson1234/searchConsoleR. http://www.google.com/webmasters/tools/,
+     https://developers.google.com/webmaster-tools/
+BugReports: https://github.com/MarkEdmondson1234/searchConsoleR/issues
 Depends: R (>= 3.2.0)
 License: MIT + file LICENSE
 LazyData: true

--- a/R/getData.R
+++ b/R/getData.R
@@ -217,7 +217,7 @@ list_websites <- function() {
 #' @export
 add_website <- function(siteURL) {
   
-  siteURL <- check.Url(siteURL, reserved=T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
   
   aw <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "PUT",
@@ -239,7 +239,7 @@ add_website <- function(siteURL) {
 #' @family search console website functions
 delete_website <- function(siteURL) {
   
-  siteURL <- check.Url(siteURL, reserved=T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
   
   
   dw <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
@@ -264,7 +264,7 @@ delete_website <- function(siteURL) {
 #' @family sitemap admin functions
 list_sitemaps <- function(siteURL) {
   
-  siteURL <- check.Url(siteURL, reserved=T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
   
   ls <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "GET",
@@ -289,8 +289,8 @@ list_sitemaps <- function(siteURL) {
 #' @family sitemap admin functions
 add_sitemap <- function(siteURL, feedpath) {
   
-  siteURL <- check.Url(siteURL, reserved=T)
-  feedpath <- check.Url(feedpath, reserved = T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
+  feedpath <- check.Url(feedpath, reserved = TRUE)
   
   as <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "PUT",
@@ -316,8 +316,8 @@ add_sitemap <- function(siteURL, feedpath) {
 #' @family sitemap admin functions
 delete_sitemap <- function(siteURL, feedpath) {
   
-  siteURL <- check.Url(siteURL, reserved=T)
-  feedpath <- check.Url(feedpath, reserved = T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
+  feedpath <- check.Url(feedpath, reserved = TRUE)
   
   ds <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "DELETE",
@@ -356,9 +356,9 @@ delete_sitemap <- function(siteURL, feedpath) {
 crawl_errors <- function(siteURL, 
                          category="all",
                          platform=c("all","mobile","smartphoneOnly","web"),
-                         latestCountsOnly=FALSE) {
+                         latestCountsOnly = FALSE) {
   platform <- match.arg(platform)
-  siteURL <- check.Url(siteURL, reserved=T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
   
   latestCountsOnly <- ifelse(latestCountsOnly, 'true', 'false')
   
@@ -453,8 +453,8 @@ error_sample_url <- function(siteURL,
                              category="notFound",
                              platform="web") {
   
-  siteURL <- check.Url(siteURL, reserved=T)
-  pageURL <- check.Url(pageURL, checkProtocol = F, reserved = T, repeated=T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
+  pageURL <- check.Url(pageURL, checkProtocol = FALSE, reserved = TRUE, repeated = TRUE)
   
 
   ## require pre-existing token, to avoid recursion
@@ -505,11 +505,11 @@ error_sample_url <- function(siteURL,
 #' @export
 fix_sample_url <- function(siteURL,
                            pageURL,
-                           category="notFound",
-                           platform="web") {
+                           category = "notFound",
+                           platform = "web") {
   
-  siteURL <- check.Url(siteURL, reserved=T)
-  pageURL <- check.Url(pageURL, checkProtocol = F, reserved = T)
+  siteURL <- check.Url(siteURL, reserved = TRUE)
+  pageURL <- check.Url(pageURL, checkProtocol = FALSE, reserved = TRUE)
  
   if(is.valid.category.platform(category, platform)){
     
@@ -526,8 +526,9 @@ fix_sample_url <- function(siteURL,
                               urlCrawlErrorsSamples = pageURL), 
         pars_arguments = params)
     
-    TRUE
+    return(TRUE)
     
   }
   
+  return(FALSE)
 }

--- a/searchConsoleR.Rproj
+++ b/searchConsoleR.Rproj
@@ -1,0 +1,21 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --as-cran
+PackageRoxygenize: rd,collate,namespace,vignette


### PR DESCRIPTION
A serious of miscellaneous fixes. Specifically:

1. Amend the .Rbuildignore to ignore the travis and CRAN-comments files, thus removing the NOTEs (and avoiding shipping these files with the built package, which is probably not what you want).
2. Amend the .gitignore to no longer miss the .Rbuildignore and .Rproj. Missing these files means that people attempting to build off the package, or patch it, may be using totally different defaults from the upstream source, creating issues that previously didn't exist (or masking issues that did).
3. Include references to the project in the URL and BugReports field in the DESCRIPTION to make reporting issues or submitting PRs easier.
4. Reformat the vignette so that the title displays correctly on CRAN.
5. Change T and F usage to TRUE and FALSE, which is preferred since T/F aren't actually safe constants.