### PR TITLE
Added searchAppearance as a dimension option

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ cran-comments\.md
 .httr-oauth
 .httr-oauth.SUSPENDED
 news.md
+^\.httr-oauth$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Google Search Console R Client
 Version: 0.2.1.9000
 Authors@R: c(person("Mark", "Edmondson",email = "r@sunholo.com",
                   role = c("aut", "cre")),
-           person("Jennifer", "Bryan",email="jenny@stat.ubc.ca", role = "ctb"))
+           person("Jennifer", "Bryan",email="jenny@stat.ubc.ca", role = "ctb"),
+           person("Parzakonis", "Manos",email="parzakonis,m@gmail.com", role = "ctb"))
 Description: Provides an interface with the Google Search Console,
     formally called Google Webmaster Tools.
 URL: http://code.markedmondson.me/searchConsoleR/

--- a/R/getData.R
+++ b/R/getData.R
@@ -6,99 +6,102 @@ options("googleAuthR.webapp.client_secret" = getOption("searchConsoleR.webapp.cl
 
 
 #' Query search traffic keyword data
-#' 
+#'
 #' @description Download your Google SEO data.
-#' 
+#'
 #' @param siteURL The URL of the website you have auth access to.
 #' @param startDate Start date of requested range, in YYYY-MM-DD.
 #' @param endDate End date of the requested date range, in YYYY-MM-DD.
-#' @param dimensions Zero or more dimensions to group results by: 
-#'      \code{"date", "country", "device", "page" or "query"}
+#' @param dimensions Zero or more dimensions to group results by:
+#'      \code{"date", "country", "device", "page" , "query" or "searchAppearance"}
 #' @param searchType Search type filter, default 'web'.
-#' @param dimensionFilterExp A character vector of expressions to filter. 
+#' @param dimensionFilterExp A character vector of expressions to filter.
 #'      e.g. \code{("device==TABLET", "country~~GBR")}
 #' @param aggregationType How data is aggregated.
 #' @param rowLimit How many rows, maximum is 5000.
-#' @param prettyNames If TRUE, converts SO 3166-1 alpha-3 country code to full name and 
+#' @param prettyNames If TRUE, converts SO 3166-1 alpha-3 country code to full name and
 #'   creates new column called countryName.
 #' @param walk_data Make multiple API calls. One of \code{("byBatch","byDate","none")}
-#' 
+#'
 #' @return A dataframe with columns in order of dimensions plus metrics, with attribute "aggregationType"
-#' 
+#'
 #' @seealso Guide to Search Analytics: \url{https://support.google.com/webmasters/answer/6155685}
 #'   API docs: \url{https://developers.google.com/webmaster-tools/v3/searchanalytics/query}
 #' @export
-#' 
-#' @details 
-#'  \strong{startDate}: Start date of the requested date range, in YYYY-MM-DD format, 
-#'    in PST time (UTC - 8:00). Must be less than or equal to the end date. 
+#'
+#' @details
+#'  \strong{startDate}: Start date of the requested date range, in YYYY-MM-DD format,
+#'    in PST time (UTC - 8:00). Must be less than or equal to the end date.
 #'    This value is included in the range.
-#'    
-#'  \strong{endDate}: End date of the requested date range, in YYYY-MM-DD format, 
-#'    in PST time (UTC - 8:00). Must be greater than or equal to the start date. 
+#'
+#'  \strong{endDate}: End date of the requested date range, in YYYY-MM-DD format,
+#'    in PST time (UTC - 8:00). Must be greater than or equal to the start date.
 #'    This value is included in the range.
-#'    
-#'  \strong{dimensions}: [Optional] Zero or more dimensions to group results by. 
+#'
+#'  \strong{dimensions}: [Optional] Zero or more dimensions to group results by.
 #'       \itemize{
 #'         \item 'date'
 #'         \item 'country'
 #'         \item 'device'
 #'         \item 'page'
 #'         \item 'query'
+#'         \item 'searchAppearance'
 #'       }
-#'  The grouping dimension values are combined to create a unique key 
-#'    for each result row. If no dimensions are specified, 
-#'    all values will be combined into a single row. 
-#'    There is no limit to the number of dimensions that you can group by, 
+#'  The grouping dimension values are combined to create a unique key
+#'    for each result row. If no dimensions are specified,
+#'    all values will be combined into a single row.
+#'    There is no limit to the number of dimensions that you can group by,
 #'    but you cannot group by the same dimension twice. Example: c(country, device)
-#'  
+#'
 #'  \strong{dimensionFilterExp}:
-#'  Results are grouped in the order that you supply these dimensions. 
+#'  Results are grouped in the order that you supply these dimensions.
 #'  dimensionFilterExp expects a character vector of expressions in the form:
 #'   ("device==TABLET", "country~~GBR", "dimension operator expression")
 #'   \itemize{
-#'     \item dimension  
+#'     \item dimension
 #'       \itemize{
 #'         \item 'country'
 #'         \item 'device'
 #'         \item 'page'
 #'         \item 'query'
+#'         \item 'searchAppearance'
 #'       }
-#'     \item operator 
+#'     \item operator
 #'       \itemize{
 #'         \item '~~' meaning 'contains'
 #'         \item '==' meaning 'equals'
 #'         \item '!~' meaning 'notContains'
 #'         \item '!=' meaning 'notEquals
 #'       }
-#'     
-#'     \item expression 
+#'
+#'     \item expression
 #'        \itemize{
 #'          \item country: an ISO 3166-1 alpha-3 country code.
 #'          \item device: 'DESKTOP','MOBILE','TABLET'.
 #'          \item page: not checked, a string in page URLs without hostname.
 #'          \item query: not checked, a string in keywords.
-#'        
+#'          \item searchAppearance: 'AMP_BLUE_LINK', 'RICHCARD'
+#'
 #'        }
 #'   }
-#'  
-#'  
+#'
+#'
 #'  \strong{searchType}: [Optional] The search type to filter for. Acceptable values are:
 #'  \itemize{
 #'    \item "web": [Default] Web search results
 #'    \item "image": Image search results
 #'    \item "video": Video search results
 #'  }
-#'  
-#'  \strong{aggregationType}: [Optional] How data is aggregated. 
+#'
+#'  \strong{aggregationType}: [Optional] How data is aggregated.
 #'  \itemize{
-#'    \item If aggregated by property, all data for the same property is aggregated; 
-#'    \item If aggregated by page, all data is aggregated by canonical URI. 
-#'    \item If you filter or group by page, choose auto; otherwise you can aggregate either by property or by page, depending on how you want your data calculated; 
+#'    \item If aggregated by property, all data for the same property is aggregated;
+#'    \item If aggregated by page, all data is aggregated by canonical URI.
+#'    \item If you filter or group by page, choose auto; otherwise you can aggregate either by property or by page, depending on how you want your data calculated;
 #'  }
-#'    See the API documentation to learn how data is calculated differently by site versus by page. 
+#'    See the API documentation to learn how data is calculated differently by site versus by page.
 #'    Note: If you group or filter by page, you cannot aggregate by property.
-#'    If you specify any value other than auto, the aggregation type in the result will match the requested type, or if you request an invalid type, you will get an error. 
+#'    If you specify any value other than auto, the aggregation type in the result will match the requested type, or if you request an invalid type, you will get an error.
 #'    The API will never change your aggregation type if the requested type is invalid.
 #'    Acceptable values are:
 #'  \itemize{
@@ -106,102 +109,104 @@ options("googleAuthR.webapp.client_secret" = getOption("searchConsoleR.webapp.cl
 #'    \item "byPage": Aggregate values by URI.
 #'    \item "byProperty": Aggregate values by property.
 #'  }
-#'  
+#'
 #'  \strong{batchType}: [Optional] Batching data into multiple API calls
 #' \itemize{
 #'   \item byBatch Use the API call to batch
 #'   \item byData Runs a call over each day in the date range.
 #'   \item none No batching
 #'  }
-#'  
-#' @examples 
-#' 
+#'
+#' @examples
+#'
 #' \dontrun{
-#'  
+#'
 #'    library(searchConsoleR)
 #'    scr_auth()
 #'    sc_websites <- list_websites()
-#'    
-#'    gbr_desktop_queries <- 
+#'
+#'    gbr_desktop_queries <-
 #'        search_analytics("http://www.example.com",
 #'                          start = "2016-01-01", end = "2016-03-01",
 #'                          dimensions = c("query", "page"),
 #'                          dimensionsFilterExp = c("device==DESKTOP", "country==GBR"),
 #'                          searchType = "web", rowLimit = 100)
-#'                          
-#'    batching <- 
+#'
+#'    batching <-
 #'         search_analytics("http://www.example.com",
 #'                          start = "2016-01-01", end = "2016-03-01",
 #'                          dimensions = c("query", "page", "date"),
 #'                          searchType = "web", rowLimit = 100000,
-#'                          walk_data = "byBatch") 
-#'   
-#'   }  
-search_analytics <- function(siteURL, 
-                             startDate = Sys.Date() - 93, 
-                             endDate = Sys.Date() - 3, 
-                             dimensions = NULL, 
+#'                          walk_data = "byBatch")
+#'
+#'   }
+search_analytics <- function(siteURL,
+                             startDate = Sys.Date() - 93,
+                             endDate = Sys.Date() - 3,
+                             dimensions = NULL,
                              searchType = c("web","video","image"),
+                             searchAppearance = NULL,
                              dimensionFilterExp = NULL,
                              aggregationType = c("auto","byPage","byProperty"),
                              rowLimit = 1000,
                              prettyNames = TRUE,
                              walk_data = c("byBatch","byDate","none")){
-  
+
   authenticated <- "Token2.0" %in% class(googleAuthR::Authentication$public_fields$token)
   if(!authenticated){
     stop("Not authenticated. Run scr_auth()", call. = FALSE)
   }
-  
+
   searchType      <- match.arg(searchType)
   aggregationType <- match.arg(aggregationType)
   walk_data       <- match.arg(walk_data)
-  
+
   startDate <- as.character(startDate)
-  endDate   <- as.character(endDate)  
-  
+  endDate   <- as.character(endDate)
 
 
-  message("Fetching search analytics for ", 
-          paste("url:", siteURL, 
+
+  message("Fetching search analytics for ",
+          paste("url:", siteURL,
                 "dates:", startDate, endDate,
                 "dimensions:", paste(dimensions, collapse = " ", sep=";"),
-                "dimensionFilterExp:", paste(dimensionFilterExp, collapse = " ", sep=";"), 
-                "searchType:", searchType, 
+                "dimensionFilterExp:", paste(dimensionFilterExp, collapse = " ", sep=";"),
+                "searchType:", searchType,
+                "searchAppearance:", searchAppearance,
                 "aggregationType:", aggregationType))
-  
+
   siteURL <- check.Url(siteURL, reserved=T)
 
   if(any(is.na(as.Date(startDate, "%Y-%m-%d")), is.na(as.Date(endDate, "%Y-%m-%d")))){
     stop("dates not in correct %Y-%m-%d format. Got these:", startDate, " - ", endDate)
   }
-  
+
   if(any(as.Date(startDate, "%Y-%m-%d") > Sys.Date()-3, as.Date(endDate, "%Y-%m-%d") > Sys.Date()-3)){
     warning("Search Analytics usually not available within 3 days (96 hrs) of today(",Sys.Date(),"). Got:", startDate, " - ", endDate)
   }
-  
+
   if(as.Date(startDate, "%Y-%m-%d") < Sys.Date()-93){
     warning("Search Analytics usually not available 93 days before today(",Sys.Date(),"). Got:", startDate, " - ", endDate)
   }
-  
+
   if(!is.null(dimensions) && !dimensions %in% c('date','country', 'device', 'page', 'query')){
-    stop("dimension must be NULL or one or more of 'date','country', 'device', 'page', 'query'. 
+    stop("dimension must be NULL or one or more of 'date','country', 'device', 'page', 'query'.
          Got this: ", paste(dimensions, sep=", "))
   }
-  
+
   if(!searchType %in% c("web","image","video")){
     stop('searchType not one of "web","image","video".  Got this: ', searchType)
   }
 
-  
+
   if(!aggregationType %in% c("auto","byPage","byProperty")){
     stop('aggregationType not one of "auto","byPage","byProperty". Got this: ', aggregationType)
   }
-  
+
   if(aggregationType %in% c("byProperty") && 'page' %in% dimensions ){
     stop("Can't aggregate byProperty and include page in dimensions.")
   }
-  
+
   if(rowLimit > 5000){
     message("Batching data via method: ", walk_data)
     rowLimit0 <- rowLimit
@@ -209,18 +214,19 @@ search_analytics <- function(siteURL,
   } else {
     walk_data <- "none"
   }
-  
+
   ## require pre-existing token, to avoid recursion
-    
-  ## a list of filter expressions 
+
+  ## a list of filter expressions
   ## expects dimensionFilterExp like c("device==TABLET", "country~~GBR")
   parsedDimFilterGroup <- lapply(dimensionFilterExp, parseDimFilterGroup)
-  
+
   body <- list(
     startDate = startDate,
     endDate = endDate,
-    dimensions = as.list(dimensions),  
+    dimensions = as.list(dimensions),
     searchType = searchType,
+    searchAppearance = searchAppearance,
     dimensionFilterGroups = list(
       list( ## you don't want more than one of these until different groupType available
         groupType = "and", ##only one available for now
@@ -230,24 +236,24 @@ search_analytics <- function(siteURL,
     aggregationType = aggregationType,
     rowLimit = rowLimit
   )
-  
-  search_analytics_g <- 
+
+  search_analytics_g <-
     googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                    "POST",
                                    path_args = list(sites = "siteURL",
                                                     searchAnalytics = "query"),
                                    data_parse_function = parse_search_analytics
                                    )
-  
+
   if(walk_data == "byDate"){
-    
+
     if(!'date' %in% dimensions){
-      stop("To walk data per date requires 'date' to be one of the dimensions. 
+      stop("To walk data per date requires 'date' to be one of the dimensions.
            Got this: ", paste(dimensions, sep=", "))
     }
-    
+
     walk_vector <- seq(as.Date(startDate), as.Date(endDate), 1)
-    
+
     out <- googleAuthR::gar_batch_walk(search_analytics_g,
                                        walk_vector = walk_vector,
                                        gar_paths = list(sites = siteURL),
@@ -255,13 +261,13 @@ search_analytics <- function(siteURL,
                                        the_body = body,
                                        batch_size = 1,
                                        dim = dimensions)
-    
+
   } else if(walk_data == "byBatch") {
-    
+
     ## byBatch uses API batching, but this pulls out less data
-    ## 0 impression keywords not included. 
+    ## 0 impression keywords not included.
     walk_vector <- seq(0, rowLimit0, 5000)
-    
+
     out <- googleAuthR::gar_batch_walk(search_analytics_g,
                                        walk_vector = walk_vector,
                                        gar_paths = list(sites = siteURL),
@@ -269,18 +275,18 @@ search_analytics <- function(siteURL,
                                        the_body = body,
                                        batch_size = 3,
                                        dim = dimensions)
-    
-    
-    
-    
+
+
+
+
   } else {
-    
-    out <-   search_analytics_g(the_body=body, 
-                                path_arguments=list(sites = siteURL), 
+
+    out <-   search_analytics_g(the_body=body,
+                                path_arguments=list(sites = siteURL),
                                 dim = dimensions)
-    
+
   }
-  
+
   out
 
 }
@@ -293,7 +299,7 @@ search_analytics <- function(siteURL,
 #' @export
 #' @family search console website functions
 list_websites <- function() {
-  
+
   l <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/sites",
                                       "GET",
                                       data_parse_function = function(x) x$siteEntry)
@@ -301,194 +307,194 @@ list_websites <- function() {
 }
 
 #' Adds website to Search Console
-#' 
+#'
 #' @param siteURL The URL of the website to add.
 #'
 #' @return TRUE if successful, raises an error if not.
 #' @family search console website functions
-#' 
+#'
 #' @export
 add_website <- function(siteURL) {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
-  
+
   aw <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "PUT",
                                       path_args = list(sites = "siteURL"))
-  
+
   aw(path_arguments = list(sites = siteURL))
   TRUE
-  
+
 }
 
 #' Deletes website in Search Console
-#' 
+#'
 #' @param siteURL The URL of the website to delete.
-#' 
+#'
 #' @return TRUE if successful, raises an error if not.
 #' @family data fetching functions
-#' 
+#'
 #' @export
 #' @family search console website functions
 delete_website <- function(siteURL) {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
-  
-  
+
+
   dw <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "DELETE",
                                       path_args = list(sites = "siteURL"))
-  
+
   dw(path_arguments = list(sites = siteURL))
   TRUE
-  
+
 }
 
 #' Gets sitemap information for the URL supplied.
-#' 
-#' See here for details: https://developers.google.com/webmaster-tools/v3/sitemaps 
-#' 
+#'
+#' See here for details: https://developers.google.com/webmaster-tools/v3/sitemaps
+#'
 #' @param siteURL The URL of the website to get sitemap information from. Must include protocol (http://).
-#' 
+#'
 #' @return A list of two dataframes: $sitemap with general info and $contents with sitemap info.
 #' @family data fetching functions
-#' 
+#'
 #' @export
 #' @family sitemap admin functions
 list_sitemaps <- function(siteURL) {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
-  
+
   ls <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "GET",
                                       path_args = list(sites = "siteURL",
                                                        sitemaps = ""),
                                       data_parse_function = parse_sitemaps)
-  
+
   ls(path_arguments = list(sites = siteURL))
-  
+
 }
 
 #' Submit a sitemap.
-#' 
+#'
 #' See here for details: https://developers.google.com/webmaster-tools/v3/sitemaps/submit
-#' 
+#'
 #' @param siteURL The URL of the website to delete. Must include protocol (http://).
 #' @param feedpath The URL of the sitemap to submit. Must include protocol (http://).
-#' 
+#'
 #' @return TRUE if successful, raises an error if not.
 #'
 #' @export
 #' @family sitemap admin functions
 add_sitemap <- function(siteURL, feedpath) {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
   feedpath <- check.Url(feedpath, reserved = TRUE)
-  
+
   as <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "PUT",
                                       path_args = list(sites = "siteURL",
                                                        sitemaps = "feedpath"))
-  
+
   as(path_arguments = list(sites = siteURL,
                           sitemaps = feedpath))
   TRUE
-  
+
 }
 
 #' Delete a sitemap.
-#' 
+#'
 #' See here for details: https://developers.google.com/webmaster-tools/v3/sitemaps/delete
-#' 
+#'
 #' @param siteURL The URL of the website you are deleting the sitemap from. Must include protocol (http://).
 #' @param feedpath The URL of the sitemap to delete. Must include protocol (http://).
-#' 
+#'
 #' @return TRUE if successful, raises an error if not.
 #'
 #' @export
 #' @family sitemap admin functions
 delete_sitemap <- function(siteURL, feedpath) {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
   feedpath <- check.Url(feedpath, reserved = TRUE)
-  
+
   ds <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                       "DELETE",
                                       path_args = list(sites = "siteURL",
                                                        sitemaps = "feedpath"))
-  
+
   ds(path_arguments = list(sites = siteURL,
                           sitemaps = feedpath))
-  
+
   TRUE
-  
+
 }
 
 #' Fetch a time-series of Googlebot crawl errors.
-#' 
-#' @description 
+#'
+#' @description
 #' Get a list of errors detected by Googlebot over time.
 #' See here for details: https://developers.google.com/webmaster-tools/v3/urlcrawlerrorscounts/query
-#' 
+#'
 #' @param siteURL The URL of the website to delete. Must include protocol (http://).
 #' @param category Crawl error category. Defaults to 'all'
 #' @param platform The user agent type. 'all', 'mobile', 'smartphoneOnly' or 'web'.
 #' @param latestCountsOnly Default FALSE. Only the latest crawl error counts returned if TRUE.
-#' 
+#'
 #' @return dataframe of errors with $platform $category $count and $timecount.
 #'
 #' @details The timestamp is converted to a date as they are only available daily.
-#' 
+#'
 #' Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
 #'   other, roboted, serverError, soft404.
-#'   
+#'
 #'   Platform is one of: mobile, smartphoneOnly or web.
-#' 
+#'
 #' @export
 #' @family working with search console errors
-crawl_errors <- function(siteURL, 
+crawl_errors <- function(siteURL,
                          category="all",
                          platform=c("all","mobile","smartphoneOnly","web"),
                          latestCountsOnly = FALSE) {
   platform <- match.arg(platform)
   siteURL <- check.Url(siteURL, reserved = TRUE)
-  
+
   latestCountsOnly <- ifelse(latestCountsOnly, 'true', 'false')
-  
+
   ## require pre-existing token, to avoid recursion
   if(is.valid.category.platform(category, platform, include.all = TRUE)) {
-    
+
     params <- list('category' = category,
                    'latestCountsOnly' = latestCountsOnly,
                    'platform' = platform)
     params <- params[params != 'all']
-    
+
     ce <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                          "GET",
                                          path_args = list(sites = "siteURL",
                                                           urlCrawlErrorsCounts = "query"),
                                          pars_args = params,
                                          data_parse_function = parse_crawlerrors)
-    
+
     ce(path_arguments = list(sites = siteURL), pars_arguments = params)
-  
+
   }
 }
 
 #' Lists a site's sample URLs for crawl errors.
-#' 
+#'
 #' @description Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
 #'   other, roboted, serverError, soft404.
-#'   
+#'
 #'   Platform is one of: mobile, smartphoneOnly or web.
-#' 
+#'
 #' @param siteURL The URL of the website to delete. Must include protocol (http://).
 #' @param category Crawl error category. Default 'notFound'.
 #' @param platform User agent type. Default 'web'.
 #'
 #' @details
 #' See here for details: \url{https://developers.google.com/webmaster-tools/v3/urlcrawlerrorssamples}
-#' 
+#'
 #' @return A dataframe of $pageUrl, $last_crawled, $first_detected, $response
 #'
 #' @export
@@ -496,48 +502,48 @@ crawl_errors <- function(siteURL,
 list_crawl_error_samples <- function(siteURL,
                                      category="notFound",
                                      platform="web") {
-  
+
   siteURL <- check.Url(siteURL, reserved=T)
 
   ## require pre-existing token, to avoid recursion
   if(is.valid.category.platform(category, platform)) {
-    
+
     params <- list('category' = category,
                    'platform' = platform)
-    
-    lces <- 
+
+    lces <-
       googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                      "GET",
                                      path_args = list(sites = "siteURL",
                                                       urlCrawlErrorsSamples = ""),
                                      pars_args = params,
                                      data_parse_function = parse_crawlerror_sample)
-    
+
     lces(path_arguments = list(sites = siteURL), pars_arguments = params)
   }
-  
+
 }
 
 #' Shows details of errors for individual sample URLs
-#' 
-#' See here for details: https://developers.google.com/webmaster-tools/v3/urlcrawlerrorssamples/get 
-#' 
+#'
+#' See here for details: https://developers.google.com/webmaster-tools/v3/urlcrawlerrorssamples/get
+#'
 #' @param siteURL The URL of the website to delete. Must include protocol (http://).
 #' @param pageURL A PageUrl taken from list_crawl_error_samples.
 #' @param category Crawl error category. Default 'notFound'.
 #' @param platform User agent type. Default 'web'.
-#' 
+#'
 #' @return Dataframe of $linkedFrom, with the calling URLs $last_crawled, $first_detected and a $exampleURL
 #' @family working with search console errors
-#' @description 
-#' pageURL is the relative path (without the site) of the sample URL. 
-#' It must be one of the URLs returned by list_crawl_error_samples. 
-#' For example, for the URL https://www.example.com/pagename on the site https://www.example.com/, 
+#' @description
+#' pageURL is the relative path (without the site) of the sample URL.
+#' It must be one of the URLs returned by list_crawl_error_samples.
+#' For example, for the URL https://www.example.com/pagename on the site https://www.example.com/,
 #' the url value is pagename (string)
-#' 
+#'
 #' Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
 #'   other, roboted, serverError, soft404.
-#'   
+#'
 #'   Platform is one of: mobile, smartphoneOnly or web.
 #'
 #' @export
@@ -545,54 +551,54 @@ error_sample_url <- function(siteURL,
                              pageURL,
                              category="notFound",
                              platform="web") {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
   pageURL <- check.Url(pageURL, checkProtocol = FALSE, reserved = TRUE, repeated = TRUE)
-  
+
 
   ## require pre-existing token, to avoid recursion
   if(is.valid.category.platform(category, platform)){
-    
+
     params <- list('category' = category,
                    'platform' = platform)
-    
+
     esu <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                           "GET",
                                           path_args = list(sites = "siteURL",
                                                            urlCrawlErrorsSamples = "pageURL"),
                                           pars_args = params,
                                           data_parse_function = parse_errorsample_url)
-    
+
     esu(path_arguments = list(sites = siteURL,
-                              urlCrawlErrorsSamples = pageURL), 
+                              urlCrawlErrorsSamples = pageURL),
         pars_arguments = params)
 
   }
-  
+
 }
 
 #' Mark As Fixed the individual sample URLs
-#' 
-#' See here for details: 
+#'
+#' See here for details:
 #' https://developers.google.com/webmaster-tools/v3/urlcrawlerrorssamples/markAsFixed
-#' 
+#'
 #' @param siteURL The URL of the website to delete. Must include protocol (http://).
 #' @param pageURL A PageUrl taken from list_crawl_error_samples.
 #' @param category Crawl error category. Default 'notFound'.
 #' @param platform User agent type. Default 'web'.
-#' 
+#'
 #' @return TRUE if successful, raises an error if not.
 #' @family working with search console errors
-#' 
-#' @description 
-#' pageURL is the relative path (without the site) of the sample URL. 
-#' It must be one of the URLs returned by list_crawl_error_samples. 
-#' For example, for the URL https://www.example.com/pagename on the site https://www.example.com/, 
+#'
+#' @description
+#' pageURL is the relative path (without the site) of the sample URL.
+#' It must be one of the URLs returned by list_crawl_error_samples.
+#' For example, for the URL https://www.example.com/pagename on the site https://www.example.com/,
 #' the url value is pagename (string)
-#' 
+#'
 #' Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
 #'   other, roboted, serverError, soft404.
-#'   
+#'
 #'   Platform is one of: mobile, smartphoneOnly or web.
 #'
 #' @export
@@ -600,28 +606,28 @@ fix_sample_url <- function(siteURL,
                            pageURL,
                            category = "notFound",
                            platform = "web") {
-  
+
   siteURL <- check.Url(siteURL, reserved = TRUE)
   pageURL <- check.Url(pageURL, checkProtocol = FALSE, reserved = TRUE)
- 
+
   if(is.valid.category.platform(category, platform)){
-    
+
     params <- list('category' = category,
                    'platform' = platform)
-    
+
     fsu <- googleAuthR::gar_api_generator("https://www.googleapis.com/webmasters/v3/",
                                           "DELETE",
                                           path_args = list(sites = "siteURL",
                                                            urlCrawlErrorsSamples = "pageURL"),
                                           pars_args = params)
-    
+
     fsu(path_arguments = list(sites = siteURL,
-                              urlCrawlErrorsSamples = pageURL), 
+                              urlCrawlErrorsSamples = pageURL),
         pars_arguments = params)
-    
+
     return(TRUE)
-    
+
   }
-  
+
   return(FALSE)
 }

--- a/R/reqParse.R
+++ b/R/reqParse.R
@@ -1,22 +1,22 @@
 #' Parsing function for \code{\link{search_analytics}}
-#' 
+#'
 #' @param x req$content from API response
 #' @param dim the dimensions passed from search_analytics
 #' @param pn PrettyNames passed from search_analytics
-#' 
+#'
 #' @keywords internal
 #' @family parsing functions
 parse_search_analytics <- function(x, dim, prettyNames=TRUE){
-  
+
   the_data <- x$rows
 
   if(!is.null(dim)){
     # a bit of jiggery pokery (data processing)
-    dimensionCols <- data.frame(Reduce(rbind, 
-                                       lapply(the_data$keys, function(x) 
-                                         rbind(x))), 
+    dimensionCols <- data.frame(Reduce(rbind,
+                                       lapply(the_data$keys, function(x)
+                                         rbind(x))),
                                 row.names=NULL, stringsAsFactors = F)
-    
+
     ## if no rows, get out of here.
     if(!nrow(dimensionCols) > 0) {
       warning("No data found")
@@ -25,22 +25,22 @@ parse_search_analytics <- function(x, dim, prettyNames=TRUE){
       if('date' %in% dim) empty_df$date <- as.Date(NA)
       return(empty_df)
     }
-    
+
     names(dimensionCols ) <- dim
     dimensionCols <- lapply(dimensionCols, unname)
-    
+
     if('date' %in% names(dimensionCols)){
       dimensionCols$date <- as.Date(dimensionCols$date)
     }
-    
+
     if(all('country' %in% names(dimensionCols), prettyNames)){
       dimensionCols$countryName <- sapply(dimensionCols$country, lookupCountryCode)
     }
-    
+
     metricCols <- the_data[setdiff(names(the_data), 'keys')]
-    
+
     the_df <- data.frame(dimensionCols , metricCols, stringsAsFactors = F, row.names = NULL)
-    
+
   } else { ## no dimensions
     if(!is.null(the_data)){
       the_df <- the_data
@@ -55,91 +55,91 @@ parse_search_analytics <- function(x, dim, prettyNames=TRUE){
   }
 
   attr(the_df, "aggregationType") <- x$responseAggregationType
-  
+
   the_df
-  
+
 }
 
 #' Parsing function for \code{\link{list_sitemaps}}
-#' 
+#'
 #' @param x req$content from API response
-#' 
+#'
 #' @keywords internal
 #' @family parsing functions
 parse_sitemaps <- function(x){
   list(sitemap = x$sitemap[, setdiff(names(x$sitemap), "contents")],
        contents = x$sitemap$contents)
-  
+
 }
 
 #' Parsing function for \code{\link{crawl_errors}}
-#' 
+#'
 #' @param x req$content from API response
-#' 
+#'
 #' @keywords internal
 #' @family parsing functions
 parse_crawlerrors <- function(x){
   cpt <- x$countPerTypes
   ## data parsing gymnastics
-  ldf <- Reduce(rbind, 
+  ldf <- Reduce(rbind,
                 apply(cpt, 1, function(row) {
-                  data.frame(platform = row['platform'], 
-                             category = row['category'], 
-                             count = row$entries$count, 
+                  data.frame(platform = row['platform'],
+                             category = row['category'],
+                             count = row$entries$count,
                              timecount = row$entries$timestamp )
                 })
   )
-  
+
   ## transform to something useable
   ldf$platform <- as.character(ldf$platform)
   ldf$category <- as.character(ldf$category)
   ldf$count <- as.numeric(as.character(ldf$count))
   ldf$timecount <- RFC_convert(ldf$timecount, drop_time = TRUE)
-  
+
   ldf
-  
+
 }
 
 #' Parsing function for \code{\link{list_crawl_error_samples}}
-#' 
+#'
 #' @param x req$content from API response
-#' 
+#'
 #' @keywords internal
 #' @family parsing functions
 parse_crawlerror_sample <- function(x){
   errs <- x$urlCrawlErrorSample
-  
+
   if(!is.null(errs)){
     errs$last_crawled <- RFC_convert(errs$last_crawled)
     errs$first_detected <- RFC_convert(errs$first_detected)
-    
+
     errs      
   } else {
     message("No error samples available.")
     NULL
   }
-  
+
 }
 
 #' Parsing function for \code{\link{error_sample_url}}
-#' 
+#'
 #' @param x req$content from API response
-#' 
+#'
 #' @keywords internal
 #' @family parsing functions
 parse_errorsample_url <- function(x){
   raw_details <- x
-  
+
   if(all(c('last_crawled', 'first_detected') %in% names(raw_details))){
     raw_details$last_crawled <- RFC_convert(raw_details$last_crawled)
     raw_details$first_detected <- RFC_convert(raw_details$first_detected)
     inner_details <- Reduce(rbind, raw_details$urlDetails)
-    
-    data.frame(linkedFrom=inner_details, 
+
+    data.frame(linkedFrom=inner_details,
                last_crawled=raw_details$last_crawled,
                first_detected=raw_details$first_detected,
-               pageUrl=raw_details$pageUrl) 
-    
+               pageUrl=raw_details$pageUrl)
+
   }
-  
+
 }

--- a/R/utility.R
+++ b/R/utility.R
@@ -1,47 +1,47 @@
 #' Look up the country codes
-#' 
+#'
 #' @param code the ISO 3166-1 alpha-3 country code (as used in searchConsoleR)
 #' @param name_type One of "Name", "Official_name" or "Common_name"
-#' 
+#'
 #' @return The country name string
 #' @keywords internal
 #' @family search analytics
-lookupCountryCode <- function(country.code, 
+lookupCountryCode <- function(country.code,
                               name_type = "Name"){
-  
+
   if(!name_type %in% c("Name","Official_name","Common_name")){
     stop('name_type not one of "Name","Official_name","Common_name".  Got: ', name_type)
   }
-  
+
   country.code <- stringr::str_to_upper(country.code, "en")
-  
+
   ## get lookup data
   country.codes <- ISO_3166_1[,name_type]
   names(country.codes) <- ISO_3166_1$Alpha_3
-  
+
   if(all(country.code %in% names(country.codes))){
-    code <- country.codes[country.code] 
+    code <- country.codes[country.code]
   } else {
     code <- 'Unknown Region'
   }
-  
+
   code
 }
 
 #' Do OAuth2 authentication
-#' 
+#'
 #' @param token An existing OAuth2 token, if you have one.
 #' @param new_user Set to TRUE if you want to go through the authentication flow again.
-#' 
-#' @details 
-#' This function just wraps \code{\link[googleAuthR]{gar_auth}} from googleAuthR, 
+#'
+#' @details
+#' This function just wraps \code{\link[googleAuthR]{gar_auth}} from googleAuthR,
 #'   but means you don't need to explictly load that library.
-#' 
+#'
 #' Don't use this if you are using multiple APIs aside Search Console.
-#'   
+#'
 #' @seealso \code{\link[googleAuthR]{gar_auth}}
-#' 
-#' 
+#'
+#'
 #' @export
 scr_auth <- function(token=NULL, new_user=FALSE){
   options(googleAuthR.client_id = getOption("searchConsoleR.client_id"))
@@ -53,51 +53,53 @@ scr_auth <- function(token=NULL, new_user=FALSE){
 }
 
 #' Helper function for the query dimension filters
-#' 
+#'
 #' Saves the need for 3 parameters when you just have one
-#' 
+#'
 #' @param dfe A string of form: dimension operator expression e.g. country!~GBR
-#' 
-#' @details dimension = c('country','device','page','query')
+#'
+#' @details dimension = c('country','device','page','query','searchAppearance')
 #'   operator = c(`~~` = 'contains',
 #'                `==` = 'equals',
 #'                `!~` = 'notContains',
 #'                 `!=` = 'notEquals)
-#'  
+#'
 #'  expression = country: an ISO 3166-1 alpha-3 country code.
 #'               device: 'DESKTOP','MOBILE','TABLET'
 #'               page: not checked
 #'               query: not checked
-#'          
+#'               searchAppearance: 'AMP_BLUE_LINK', 'RICHCARD'
+#'
 #' @keywords internal
 #' @family search analytics
 parseDimFilterGroup <- function(dfe){
-  
+
   ## get lookup data
   country.codes <- ISO_3166_1$Alpha_3
   devices <- c('DESKTOP','MOBILE','TABLET')
+  searchAppearance <- c('AMP_BLUE_LINK', 'RICHCARD')
   op_symbol <-  c("~~" = 'contains',
                   "==" = 'equals',
                   "!~" = 'notContains',
                   "!=" = 'notEquals')
-  
+
   ## extract variables needed
   operator <- stringr::str_extract(dfe, "[\\!=~]{2}")
   dim_ex <- stringr::str_split_fixed(dfe, "[\\!=~]{2}", n=2)
 
-  ## remove whitespace apart from expression  
+  ## remove whitespace apart from expression
   dim_ex[1] <- stringr::str_replace_all(dim_ex[1]," ","")
   operator <- stringr::str_replace_all(operator," ","")
   dim_ex[2] <- stringr::str_trim(dim_ex[2])
-  
+
   ## check variables
-  if(!dim_ex[1] %in% c('country','device','page','query')){
-    stop("dimension not one of: ", 
-         paste(c('country','device','page','query')), 
-         " Got this: ", 
+  if(!dim_ex[1] %in% c('country','device','page','query','searchAppearance')){
+    stop("dimension not one of: ",
+         paste(c('country','device','page','query','searchAppearance')),
+         " Got this: ",
          dim_ex[1])
   }
-  
+
   if(!op_symbol[operator] %in% op_symbol){
     stop("Operator not one of ~~, ==, !~ or !=.")
   }
@@ -105,16 +107,19 @@ parseDimFilterGroup <- function(dfe){
   if(is.na(operator) || nchar(dim_ex[2]) == 0){
     stop("Incorrect format of filter: Need 'dimension' 'operator' 'expression'. e.g. 'country!~GBR' or 'device==MOBILE'. Got this:   ", dfe)
   }
-  
-  if(dim_ex[1] == "country" && 
+
+  if(dim_ex[1] == "country" &&
      !stringr::str_to_upper(dim_ex[2], "en") %in% country.codes ){
     stop("country dimension indicated, but country code not an ISO 3166-1 alpha-3 type. e.g. GBR = United Kingdom. Got this:   ", dim_ex[2])
   }
-  
+
   if(dim_ex[1] == "device" && !dim_ex[2] %in% devices ){
     stop("device dimension indicated, but device not one of DESKTOP, MOBILE or TABLET (no quotes). Got this:   ", dim_ex[2])
   }
-  
+
+  if(dim_ex[1] == "searchAppearance" && !dim_ex[2] %in% searchAppearance ){
+    stop("searchAppearance dimension indicated, but searchAppearance not one of AMP_BLUE_LINK or RICHCARD (no quotes). Got this:   ", dim_ex[2])
+  }
   list(dimension = dim_ex[1],
        operator  = unname(op_symbol[operator]),
        expression = dim_ex[2]
@@ -122,88 +127,88 @@ parseDimFilterGroup <- function(dfe){
 }
 
 #' Is this a try error?
-#' 
+#'
 #' Utility to test errors
-#' 
+#'
 #' @param test_me an object created with try()
-#' 
+#'
 #' @return Boolean
-#' 
+#'
 #' @keywords internal
 is.error <- function(test_me){
   inherits(test_me, "try-error")
 }
 
 #' Checks valid parameters for Google Search Console
-#' 
+#'
 #' The error type listings have certain categories/platform allowed.
-#' 
+#'
 #' @return TRUE if valid, raises an error if not.
-#' 
+#'
 #' @keywords internal
 is.valid.category.platform <- function (category, platform, include.all=FALSE) {
-  
+
   categories <- getOption("searchConsoleR.valid.categories")
   platforms  <- getOption("searchConsoleR.valid.platforms")
-  
+
   if(include.all){
     categories <- c('all', categories)
     platforms <- c('all', platforms)
   }
-  
+
   if(!category %in% categories) {
     stop("Incorrect category.  Must be one of ", paste(categories, collapse=","))
   }
-  
+
   if(!platform %in% platforms){
     stop("Incorrect platform. Must be one of ", paste(platforms, collapse=", "))
   }
-  
+
   TRUE
 }
 
 #' Checks Urls are in right format for API request
-#' 
+#'
 #' @param url The URL to check for use in API request
 #' @param checkProtocol Check if URL starts with 'http'
 #' @param ... Passed to URLencode()
-#' 
+#'
 #' @return Modified url if successful, raises an error if not.
-#' 
+#'
 #' @keywords internal
 check.Url <- function(url, checkProtocol=TRUE, ...){
-  
+
   if(!is.null(url)){
     if(checkProtocol && !grepl("http|android-app|sc-set",url)){
-      stop("URL must include protocol, e.g. http://example.com - got:", url) 
+      stop("URL must include protocol, e.g. http://example.com - got:", url)
     }
-    
+
     if(!grepl("%3A%2F%2F", url)){
       url <- utils::URLencode(url, ...)
       # message("Encoding URL to ", url)
     }
-    
-    url    
-    
+
+    url
+
   } else {
     stop("Null URL")
   }
 }
 
 #' Converts RFC3339 to as.Date
-#' 
+#'
 #' @keywords internal
 RFC_convert <- function(RFC, drop_time=FALSE){
-  
+
   if(drop_time){
-    d <-   as.Date(strptime(as.character(RFC), 
-                            tz="UTC", 
+    d <-   as.Date(strptime(as.character(RFC),
+                            tz="UTC",
                             "%Y-%m-%dT%H:%M:%OSZ"))
   } else {
-    d <- strptime(as.character(RFC), 
-                  tz="UTC", 
+    d <- strptime(as.character(RFC),
+                  tz="UTC",
                   "%Y-%m-%dT%H:%M:%OSZ")
   }
-  
+
   return(d)
 }

--- a/man/crawl_errors.Rd
+++ b/man/crawl_errors.Rd
@@ -28,7 +28,7 @@ The timestamp is converted to a date as they are only available daily.
 
 Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
   other, roboted, serverError, soft404.
-  
+
   Platform is one of: mobile, smartphoneOnly or web.
 }
 \seealso{

--- a/man/error_sample_url.Rd
+++ b/man/error_sample_url.Rd
@@ -19,14 +19,14 @@ error_sample_url(siteURL, pageURL, category = "notFound", platform = "web")
 Dataframe of $linkedFrom, with the calling URLs $last_crawled, $first_detected and a $exampleURL
 }
 \description{
-pageURL is the relative path (without the site) of the sample URL. 
-It must be one of the URLs returned by list_crawl_error_samples. 
-For example, for the URL https://www.example.com/pagename on the site https://www.example.com/, 
+pageURL is the relative path (without the site) of the sample URL.
+It must be one of the URLs returned by list_crawl_error_samples.
+For example, for the URL https://www.example.com/pagename on the site https://www.example.com/,
 the url value is pagename (string)
 
 Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
   other, roboted, serverError, soft404.
-  
+
   Platform is one of: mobile, smartphoneOnly or web.
 }
 \details{

--- a/man/fix_sample_url.Rd
+++ b/man/fix_sample_url.Rd
@@ -19,18 +19,18 @@ fix_sample_url(siteURL, pageURL, category = "notFound", platform = "web")
 TRUE if successful, raises an error if not.
 }
 \description{
-pageURL is the relative path (without the site) of the sample URL. 
-It must be one of the URLs returned by list_crawl_error_samples. 
-For example, for the URL https://www.example.com/pagename on the site https://www.example.com/, 
+pageURL is the relative path (without the site) of the sample URL.
+It must be one of the URLs returned by list_crawl_error_samples.
+For example, for the URL https://www.example.com/pagename on the site https://www.example.com/,
 the url value is pagename (string)
 
 Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
   other, roboted, serverError, soft404.
-  
+
   Platform is one of: mobile, smartphoneOnly or web.
 }
 \details{
-See here for details: 
+See here for details:
 https://developers.google.com/webmaster-tools/v3/urlcrawlerrorssamples/markAsFixed
 }
 \seealso{

--- a/man/list_crawl_error_samples.Rd
+++ b/man/list_crawl_error_samples.Rd
@@ -19,7 +19,7 @@ A dataframe of $pageUrl, $last_crawled, $first_detected, $response
 \description{
 Category is one of: authPermissions, manyToOneRedirect, notFollowed, notFound,
   other, roboted, serverError, soft404.
-  
+
   Platform is one of: mobile, smartphoneOnly or web.
 }
 \details{

--- a/man/parseDimFilterGroup.Rd
+++ b/man/parseDimFilterGroup.Rd
@@ -13,16 +13,17 @@ parseDimFilterGroup(dfe)
 Saves the need for 3 parameters when you just have one
 }
 \details{
-dimension = c('country','device','page','query')
+dimension = c('country','device','page','query','searchAppearance')
   operator = c(`~~` = 'contains',
                `==` = 'equals',
                `!~` = 'notContains',
                 `!=` = 'notEquals)
- 
+
  expression = country: an ISO 3166-1 alpha-3 country code.
               device: 'DESKTOP','MOBILE','TABLET'
               page: not checked
               query: not checked
+              searchAppearance: 'AMP_BLUE_LINK', 'RICHCARD'
 }
 \seealso{
 Other search analytics: \code{\link{lookupCountryCode}}

--- a/man/scr_auth.Rd
+++ b/man/scr_auth.Rd
@@ -15,7 +15,7 @@ scr_auth(token = NULL, new_user = FALSE)
 Do OAuth2 authentication
 }
 \details{
-This function just wraps \code{\link[googleAuthR]{gar_auth}} from googleAuthR, 
+This function just wraps \code{\link[googleAuthR]{gar_auth}} from googleAuthR,
   but means you don't need to explictly load that library.
 
 Don't use this if you are using multiple APIs aside Search Console.

--- a/man/search_analytics.Rd
+++ b/man/search_analytics.Rd
@@ -6,9 +6,9 @@
 \usage{
 search_analytics(siteURL, startDate = Sys.Date() - 93, endDate = Sys.Date()
   - 3, dimensions = NULL, searchType = c("web", "video", "image"),
-  dimensionFilterExp = NULL, aggregationType = c("auto", "byPage",
-  "byProperty"), rowLimit = 1000, prettyNames = TRUE,
-  walk_data = c("byBatch", "byDate", "none"))
+  searchAppearance = NULL, dimensionFilterExp = NULL,
+  aggregationType = c("auto", "byPage", "byProperty"), rowLimit = 1000,
+  prettyNames = TRUE, walk_data = c("byBatch", "byDate", "none"))
 }
 \arguments{
 \item{siteURL}{The URL of the website you have auth access to.}
@@ -17,19 +17,19 @@ search_analytics(siteURL, startDate = Sys.Date() - 93, endDate = Sys.Date()
 
 \item{endDate}{End date of the requested date range, in YYYY-MM-DD.}
 
-\item{dimensions}{Zero or more dimensions to group results by: 
-\code{"date", "country", "device", "page" or "query"}}
+\item{dimensions}{Zero or more dimensions to group results by:
+\code{"date", "country", "device", "page" , "query" or "searchAppearance"}}
 
 \item{searchType}{Search type filter, default 'web'.}
 
-\item{dimensionFilterExp}{A character vector of expressions to filter. 
+\item{dimensionFilterExp}{A character vector of expressions to filter.
 e.g. \code{("device==TABLET", "country~~GBR")}}
 
 \item{aggregationType}{How data is aggregated.}
 
 \item{rowLimit}{How many rows, maximum is 5000.}
 
-\item{prettyNames}{If TRUE, converts SO 3166-1 alpha-3 country code to full name and 
+\item{prettyNames}{If TRUE, converts SO 3166-1 alpha-3 country code to full name and
 creates new column called countryName.}
 
 \item{walk_data}{Make multiple API calls. One of \code{("byBatch","byDate","none")}}
@@ -41,75 +41,78 @@ A dataframe with columns in order of dimensions plus metrics, with attribute "ag
 Download your Google SEO data.
 }
 \details{
-\strong{startDate}: Start date of the requested date range, in YYYY-MM-DD format, 
-   in PST time (UTC - 8:00). Must be less than or equal to the end date. 
+\strong{startDate}: Start date of the requested date range, in YYYY-MM-DD format,
+   in PST time (UTC - 8:00). Must be less than or equal to the end date.
    This value is included in the range.
-   
- \strong{endDate}: End date of the requested date range, in YYYY-MM-DD format, 
-   in PST time (UTC - 8:00). Must be greater than or equal to the start date. 
+
+ \strong{endDate}: End date of the requested date range, in YYYY-MM-DD format,
+   in PST time (UTC - 8:00). Must be greater than or equal to the start date.
    This value is included in the range.
-   
- \strong{dimensions}: [Optional] Zero or more dimensions to group results by. 
+
+ \strong{dimensions}: [Optional] Zero or more dimensions to group results by.
       \itemize{
         \item 'date'
         \item 'country'
         \item 'device'
         \item 'page'
         \item 'query'
+        \item 'searchAppearance'
       }
- The grouping dimension values are combined to create a unique key 
-   for each result row. If no dimensions are specified, 
-   all values will be combined into a single row. 
-   There is no limit to the number of dimensions that you can group by, 
+ The grouping dimension values are combined to create a unique key
+   for each result row. If no dimensions are specified,
+   all values will be combined into a single row.
+   There is no limit to the number of dimensions that you can group by,
    but you cannot group by the same dimension twice. Example: c(country, device)
- 
+
  \strong{dimensionFilterExp}:
- Results are grouped in the order that you supply these dimensions. 
+ Results are grouped in the order that you supply these dimensions.
  dimensionFilterExp expects a character vector of expressions in the form:
   ("device==TABLET", "country~~GBR", "dimension operator expression")
   \itemize{
-    \item dimension  
+    \item dimension
       \itemize{
         \item 'country'
         \item 'device'
         \item 'page'
         \item 'query'
+        \item 'searchAppearance'
       }
-    \item operator 
+    \item operator
       \itemize{
         \item '~~' meaning 'contains'
         \item '==' meaning 'equals'
         \item '!~' meaning 'notContains'
         \item '!=' meaning 'notEquals
       }
-    
-    \item expression 
+
+    \item expression
        \itemize{
          \item country: an ISO 3166-1 alpha-3 country code.
          \item device: 'DESKTOP','MOBILE','TABLET'.
          \item page: not checked, a string in page URLs without hostname.
          \item query: not checked, a string in keywords.
-       
+         \item searchAppearance: 'AMP_BLUE_LINK', 'RICHCARD'
+
        }
   }
- 
- 
+
+
  \strong{searchType}: [Optional] The search type to filter for. Acceptable values are:
  \itemize{
    \item "web": [Default] Web search results
    \item "image": Image search results
    \item "video": Video search results
  }
- 
- \strong{aggregationType}: [Optional] How data is aggregated. 
+
+ \strong{aggregationType}: [Optional] How data is aggregated.
  \itemize{
-   \item If aggregated by property, all data for the same property is aggregated; 
-   \item If aggregated by page, all data is aggregated by canonical URI. 
-   \item If you filter or group by page, choose auto; otherwise you can aggregate either by property or by page, depending on how you want your data calculated; 
+   \item If aggregated by property, all data for the same property is aggregated;
+   \item If aggregated by page, all data is aggregated by canonical URI.
+   \item If you filter or group by page, choose auto; otherwise you can aggregate either by property or by page, depending on how you want your data calculated;
  }
-   See the API documentation to learn how data is calculated differently by site versus by page. 
+   See the API documentation to learn how data is calculated differently by site versus by page.
    Note: If you group or filter by page, you cannot aggregate by property.
-   If you specify any value other than auto, the aggregation type in the result will match the requested type, or if you request an invalid type, you will get an error. 
+   If you specify any value other than auto, the aggregation type in the result will match the requested type, or if you request an invalid type, you will get an error.
    The API will never change your aggregation type if the requested type is invalid.
    Acceptable values are:
  \itemize{
@@ -117,7 +120,7 @@ Download your Google SEO data.
    \item "byPage": Aggregate values by URI.
    \item "byProperty": Aggregate values by property.
  }
- 
+
  \strong{batchType}: [Optional] Batching data into multiple API calls
 \itemize{
   \item byBatch Use the API call to batch
@@ -128,26 +131,26 @@ Download your Google SEO data.
 \examples{
 
 \dontrun{
- 
+
    library(searchConsoleR)
    scr_auth()
    sc_websites <- list_websites()
-   
-   gbr_desktop_queries <- 
+
+   gbr_desktop_queries <-
        search_analytics("http://www.example.com",
                          start = "2016-01-01", end = "2016-03-01",
                          dimensions = c("query", "page"),
                          dimensionsFilterExp = c("device==DESKTOP", "country==GBR"),
                          searchType = "web", rowLimit = 100)
-                         
-   batching <- 
+
+   batching <-
         search_analytics("http://www.example.com",
                          start = "2016-01-01", end = "2016-03-01",
                          dimensions = c("query", "page", "date"),
                          searchType = "web", rowLimit = 100000,
-                         walk_data = "byBatch") 
-  
-  }  
+                         walk_data = "byBatch")
+
+  }
 }
 \seealso{
 Guide to Search Analytics: \url{https://support.google.com/webmasters/answer/6155685}

--- a/news.md
+++ b/news.md
@@ -1,6 +1,6 @@
 # 0.2.1.9000
 
-* hmm
+* Added searchAppearance as a dimension option in search_analytics()
 
 # 0.2.1
 

--- a/news.md
+++ b/news.md
@@ -1,6 +1,6 @@
 # 0.2.1.9000
 
-* Added searchAppearance as a dimension option in search_analytics()
+* Added `searchAppearance` as a dimension option in `search_analytics()`
 
 # 0.2.1
 
@@ -11,7 +11,7 @@
 * Return an empty dataframe of NAs if no resutls in fetch instead of NULL
 * Include android-app check (#7)
 * Add `walk_data` parameter to `search_analytics` to get more data
-* Set default start and end dates in `search_analytics` to 93 days ago and 3 days ago respectivily.
+* Set default start and end dates in `search_analytics` to 93 days ago and 3 days ago respectively.
 * Correct bug for error in country code.  Will now return the 'Unknown Region' if not recognised (e.g. `CXX`)
 * Add `scr_auth` function that wraps `googleAuthR::gar_auth` so you don't need to load googleAuthR explicitly.
 
@@ -20,4 +20,4 @@
 * Move to using googleAuthR for authentication backend.
 
 ### 0.1.1
-* Change search_analytics() so if no dimensions will still return data, instead of NULL
+* Change `search_analytics()` so if no dimensions will still return data, instead of NULL

--- a/tests/testthat/test-searchConsoleR.R
+++ b/tests/testthat/test-searchConsoleR.R
@@ -38,7 +38,7 @@ test_that("Can get search analytics data lots of dims with batching", {
   
   sa <- search_analytics(my_example, 
                          startDate = "2017-04-01", endDate = "2017-04-01",
-                         dimensions = c("date","device", "country" ,"query","page"), 
+                         dimensions = c("date","device", "country" ,"query","page", "searchAppearance"), 
                          walk_data = "byBatch", 
                          rowLimit = 9999)
   

--- a/vignettes/searchConsoleR-intro.Rmd
+++ b/vignettes/searchConsoleR-intro.Rmd
@@ -84,7 +84,8 @@ gbr_desktop_queries <-
                      "2015-07-01", "2015-08-01", 
                      c("query", "page"), 
                      dimensionFilterExp = c("device==DESKTOP","country==GBR"), 
-                     searchType="web", rowLimit = 100)
+                     searchType = "web", searchAppearance = "AMP_BLUE_LINKS",
+                     aggregationType = "byPage", rowLimit = 100))
 ```
 
 
@@ -97,7 +98,8 @@ Filter can be one of:
 * 'country',
 * 'device'
 * 'page'
-* 'query')
+* 'query'
+* 'searchAppearance')
 
 Operator can be one of ```~~, ==, !~, !=``` where the symbols mean:
 
@@ -115,6 +117,11 @@ Expression for device must be one of:
 * 'MOBILE'
 * 'DESKTOP'
 * 'TABLET'
+
+Expression for searchAppearance must be one of:
+
+* 'AMP_BLUE_LINKS'
+* 'RICHCARD'
 
 You can have multiple AND filters by putting them in a character vector.  
 


### PR DESCRIPTION
I'd like to filter data on AMP or not. So, I added the `searchAppearance` in the `search_analytics()` as indicated in the documentation of [Search Console API (Search Analytics, Sitemaps, Crawl Errors)](https://developers.google.com/webmaster-tools/search-console-api-original/v3/searchanalytics/query).

Then I can get the expected results like this

`search_analytics(siteURL = "https://www.e-food.gr",searchType = "web",searchAppearance = "AMP_BLUE_LINKS",dimensions = "date",aggregationType = "byPage")`

