### PR TITLE
Typo in example Section

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -127,7 +127,7 @@
 #'        search_analytics("http://www.example.com",
 #'                          start = "2016-01-01", end = "2016-03-01",
 #'                          dimensions = c("query", "page"),
-#'                          dimensionsFilterExp = c("device==DESKTOP", "country==GBR"),
+#'                          dimensionFilterExp = c("device==DESKTOP", "country==GBR"),
 #'                          searchType = "web", rowLimit = 100)
 #'
 #'    batching <-


### PR DESCRIPTION
In the Example Section the filter param is dimensionsFilterExp instead dimensionFilterExp