### PR TITLE
Fixed error: 'length(x) = 2 > 1' in coercion to 'logical(1)'

### DIFF
--- a/R/getData.R
+++ b/R/getData.R
@@ -184,7 +184,7 @@ search_analytics <- function(siteURL,
     warning("Search Analytics usually not available within 3 days (96 hrs) of today(",Sys.Date(),"). Got:", startDate, " - ", endDate)
   }
 
-  if(!is.null(dimensions) && !dimensions %in% c('date','country', 'device', 'page', 'query','searchAppearance')){
+  if(!is.null(dimensions) && !all(dimensions %in% c('date','country', 'device', 'page', 'query','searchAppearance'))){
     stop("dimension must be NULL or one or more of 'date','country', 'device', 'page', 'query', 'searchAppearance'.
          Got this: ", paste(dimensions, sep=", "))
   }


### PR DESCRIPTION
Issue: #78 

Used the `all()` function to reduce a vector of logical values to a single logical value. This prevents the error introduced by an update to R4.2.0: "Calling && or || with LHS or (if evaluated) RHS of length greater than one is now always an error."