### PR TITLE
Added support for dataState parameter which is optional by GSC API

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
     rmarkdown,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.4.0.9000
 Authors@R: c(person("Mark", "Edmondson",email = "r@sunholo.com",
                   role = c("aut", "cre")),
            person("Jennifer", "Bryan",email="jenny@stat.ubc.ca", role = "ctb"),
-           person("Parzakonis", "Manos",email="parzakonis,m@gmail.com", role = "ctb"))
+           person("Parzakonis", "Manos",email="parzakonis,m@gmail.com", role = "ctb"),
+           person("Martin", "Zatkovic",email="martin@zatkovic.cz", role = "ctb"))
 Description: Provides an interface with the Google Search Console,
     formally called Google Webmaster Tools.
 URL: http://code.markedmondson.me/searchConsoleR/

--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ c("device==DESKTOP","country==GBR", "page!=/home", "query!~brandterm")
 
 ```OR``` filters aren't yet supported in the API.
 
+## The dataState parameter
+
+In this parameter could be used for downloading fresh data.
+
+* `final` : response will contains just final data
+* `all`   : response will contains also fresh data from lattest days
+
+In default state search_analytics function works with `final` state. Be careful with the interpretation of fresh data. They get progressively more accurate as they become final data.
+
 ## Using your own Google API project 
 
 As default `searchConsoleR` uses its own Google API project to grant requests, but if you want to use your own keys:

--- a/man/search_analytics.Rd
+++ b/man/search_analytics.Rd
@@ -14,7 +14,8 @@ search_analytics(
   aggregationType = c("auto", "byPage", "byProperty"),
   rowLimit = 1000,
   prettyNames = TRUE,
-  walk_data = c("byBatch", "byDate", "none")
+  walk_data = c("byBatch", "byDate", "none"),
+  dataState = c("final", "all")
 )
 }
 \arguments{
@@ -141,6 +142,12 @@ Download your Google SEO data.
   \item byBatch Use the API call to batch
   \item byData Runs a call over each day in the date range.
   \item none No batching
+ }
+
+ \strong{dataState}: [Optional] Which data should be downloaded from the GSC
+ \itemize{
+   \item "final": [Default] Response will include only final data
+   \item "all": Response will include fresh data (they may not be fully calculated)
  }
 }
 \examples{


### PR DESCRIPTION
In 2019 was added "fresh data" to GSC (_[source](https://developers.google.com/search/blog/2019/09/search-performance-fresh-data)_). Since 2020 are this data available in API (_[source](https://developers.google.com/search/blog/2020/12/search-console-api-updates)_) but this data aren't supported by current implementation of search_analytics function in searchConsoleR. I was exploring some GSC data and realized that this feature would be useful.

So I've added this parameter to function search_analytics and by default is set "final" source (this is how it works today). So anyone who wants fresher data will be able to download it and get notice about to interpret the results correctly. 

I tried to edit the documentation and readme, hopefully I didn't forget anything.

---

I see this might solve part of the issue: #64 